### PR TITLE
Tweaks to make early BitNode play easier

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -7,37 +7,57 @@ const FLAGS_DEF = [
   ['help', false, 'Displays this help message'],
   ['bitnode', 0, 'The bitnode you are currently in'],
 ];
+const getHelpAdditionalLines = (scriptName) => [
+  'Example:',
+  `> run ${scriptName}`,
+  `> run ${scriptName} --node 1`,
+];
 
 /**
  * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
  */
 export async function main(ns) {
+  // NOTE: The player starts the game with 8GB of ram on their local system.
   const args = ns.flags(FLAGS_DEF);
   const { help, bitnode } = args; // bitnode is a future expansion point
 
   if (help) {
     const scriptName = ns.getScriptName();
-    displayHelp({
+    return displayHelp({
       ns,
       description:
         'This script provides a quick entry point for post-aug install setup.',
       flagsDefinition: FLAGS_DEF,
-      additionalLines: [
-        'Example:',
-        `> run ${scriptName}`,
-        `> run ${scriptName} --node 1`,
-      ],
+      additionalLines: getHelpAdditionalLines(scriptName),
     });
-    return;
   }
 
   ns.exec('netmap.js', 'home', 1);
   await ns.sleep(1000);
 
+  ns.exec('source-files-map.js', 'home', 1);
+  await ns.sleep(1000);
+
+  const homeRam = ns.getServerMaxRam('home');
+  const schedulerHackloopRunType = homeRam > 64 ? 'both' : 'remote';
+  const playerSourceFiles = JSON.parse(ns.read('source-file-data.json'));
+
   ns.exec('scheduler-hacknet.js', 'home', 1);
-  ns.exec('scheduler-hackloop.js', 'home', 1, '--runType', 'both');
+  ns.exec(
+    'scheduler-hackloop.js',
+    'home',
+    1,
+    '--runType',
+    schedulerHackloopRunType,
+  );
   ns.exec('scheduler-hostloop.js', 'home', 1);
-  ns.exec('scheduler-playerActions.js', 'home', 1);
+  if (playerSourceFiles.filter((e) => e.id === 4).length > 0) {
+    ns.exec('scheduler-playerActions.js', 'home', 1);
+  } else {
+    ns.print(
+      'bypassing invoke of scheduler-playerActions since sourcefile 4 is not present on the player.',
+    );
+  }
 }
 
 /**

--- a/src/hackloop.js
+++ b/src/hackloop.js
@@ -56,7 +56,7 @@ export async function main(ns) {
   }
   ns.nuke(target);
 
-  while (true) {
+  while (moneyThresh > 0) {
     const currentSecurity = ns.getServerSecurityLevel(target);
     const currentMoney = ns.getServerMoneyAvailable(target);
     ns.print(`MoneyThresh   : ${ns.nFormat(moneyThresh, moneyFormat)}

--- a/src/libs/help.js
+++ b/src/libs/help.js
@@ -19,7 +19,7 @@ function getGreaterLength(currentMax, itemToCheck) {
 
 /**
  * @param {object} args
- * @param {import(".").NS} args.ns Use just "@param {NS} ns" if editing in game
+ * @param {import("..").NS} args.ns Use just "@param {NS} ns" if editing in game
  * @param {string} description the short description to print
  * @param {} additionalLines
  */

--- a/src/scheduler-hackloop.js
+++ b/src/scheduler-hackloop.js
@@ -197,16 +197,18 @@ export async function main(ns) {
           hackToolCount,
         });
 
+        const runTypeIncludesLocal = ['local', 'both'].indexOf(runType) !== -1;
+        const runTypeIncludesRemote =
+          ['remote', 'both'].indexOf(runType) !== -1;
         const shouldRun =
           hackSkillMet && toolCountMet && (meta.hasMoney || !alreadyHacked);
         const shouldRunLocal =
-          shouldRun &&
-          !isRunningLocal &&
-          (runType === 'local' || runType === 'both');
+          shouldRun && !isRunningLocal && runTypeIncludesLocal;
         const shouldRunRemote =
           shouldRun &&
           !isRunningRemote &&
-          (runType === 'remote' || runType === 'both');
+          meta.totalMem > 0 && // TODO: See if this prevents us from being ready to backdoor servers like CSEC
+          runTypeIncludesRemote;
 
         if (shouldRunLocal) {
           startHackWithLogging({

--- a/src/scheduler-hostloop.js
+++ b/src/scheduler-hostloop.js
@@ -1,14 +1,8 @@
-/* TODO: Update what this scripts intention is
+/* This script will purchase servers that will run remote hacking against servers in the universe with money.
+ * It is assumed that server will run a single threaded hackloop against each server that is available to be
+ * hacked.
  */
-const factionServers = [
-  'CSEC',
-  'avmnite-01h',
-  'I.I.I.I',
-  'run3theh111z',
-  'The-Cave',
-  'w-1r1d_d43m0n',
-  'darkweb',
-];
+
 /**
  * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
  */
@@ -30,8 +24,8 @@ export async function main(ns) {
 
   let running = true;
   do {
-    let workingMoney = ns.getPlayer().money * moneyPercentage;
-    let thisRunMoney = workingMoney;
+    const thisRunMoney = ns.getPlayer().money * moneyPercentage;
+    let workingMoney = thisRunMoney;
 
     let schedulerRamCost = ns.getScriptRam(schedulerScript);
     let hackScriptRamCost = ns.getScriptRam(hackScript);
@@ -55,9 +49,7 @@ export async function main(ns) {
 
     const serversMeta = JSON.parse(ns.read('netmap-data.json'));
     // we don't run hackloop.js against faction servers
-    const servers = Object.keys(serversMeta).filter((item) => {
-      return !factionServers.includes(item);
-    });
+    const servers = Object.keys(serversMeta).filter((e) => !e.factionServer);
     let totalTargetCount = servers.length;
 
     // find the most expensive server we can with money available
@@ -74,9 +66,9 @@ export async function main(ns) {
     }
 
     const outMsg = [];
-    let minimumTotalRamCost =
+    const minRequiredRam =
       totalTargetCount * hackScriptRamCost + schedulerRamCost;
-    if (minimumTotalRamCost < maxServerAffordable) {
+    if (minRequiredRam < maxServerAffordable) {
       // buy the largest affordable
       var serverName = ns.purchaseServer('hackloophost', maxServerAffordable);
 
@@ -112,11 +104,11 @@ export async function main(ns) {
       // this server can't run the bare minimum, skip this round
       outMsg.push(`Could not afford server with enought RAM`);
       outMsg.push(`Largest Affordable: ${maxServerAffordableCost}`);
-      outMsg.push(`Min RAM Cost:       ${minimumTotalRamCost}`);
+      outMsg.push(`Min RAM Cost:       ${minRequiredRam}`);
     }
 
-    outMsg.push(`Start $: ${ns.nFormat(thisRunMoney, '0.0a')}`);
-    outMsg.push(`Spent $: ${ns.nFormat(thisRunMoney - workingMoney, '0.0a')}`);
+    outMsg.push(`Start $: ${ns.nFormat(workingMoney, '0.0a')}`);
+    // outMsg.push(`Spent $: ${ns.nFormat(thisRunMoney - workingMoney, '0.0a')}`);
 
     ns.print(`${outMsg.join('\n')}`);
 

--- a/src/script-stats.js
+++ b/src/script-stats.js
@@ -1,0 +1,89 @@
+/* A quick helper script to dump some information about the target script. May be helpful in
+ * solution planning.
+ */
+
+import { displayHelp } from './libs/help';
+
+const FLAGS_DEF = [
+  ['help', false, 'Displays this help message'],
+  ['server', '', 'The server to project run against'],
+  [
+    'projectServers',
+    false,
+    'Print details of running the script on various sized servers',
+  ],
+];
+const getHelpAdditionalLines = (scriptName) => [
+  `Usage: run ${scriptName}`,
+  'Example:',
+  `> run ${scriptName} fooScript.js`,
+];
+
+/**
+ * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
+ */
+export async function main(ns) {
+  const args = ns.flags(FLAGS_DEF);
+  const { help, server, projectServers } = args;
+  if (help) {
+    displayHelp({
+      ns,
+      description:
+        'This script collects information about the supplied target script.',
+      flagsDefinition: FLAGS_DEF,
+      additionalLines: getHelpAdditionalLines(ns.getScriptName()),
+    });
+    return;
+  }
+
+  const targetScript = ns.args[0];
+  const ram = ns.getScriptRam(targetScript);
+  ns.tprint(`RAM: ${ram} GB`);
+
+  if (server !== '') {
+    // TODO: Expand to include XP, Income, etc. Will need expected args though.
+    const exp = ns.getScriptExpGain(targetScript, 'home', args.server);
+    const inc = ns.getScriptIncome(targetScript, 'home', args.server);
+    ns.tprint(`Exp: ${exp}`);
+    ns.tprint(`Inc: ${inc}`);
+  }
+
+  if (projectServers) {
+    for (let i = 1; i <= 20; i++) {
+      const size = Math.pow(2, i);
+      const cost = ns.getPurchasedServerCost(size);
+      const maxThreads = Math.floor(size / ram);
+
+      ns.tprint(
+        `${size}GB @ ${ns.nFormat(cost, '$0.0a')} - ${maxThreads} threads`,
+      );
+    }
+  }
+}
+
+/**
+ * @typedef {object} AutocompleteData https://bitburner.readthedocs.io/en/latest/netscript/advancedfunctions/autocomplete.html
+ * @property {array<string>} servers List of all servers in the game
+ * @property {array<string>} txts List of all text files on the current computer
+ * @property {array<string>} scripts List of all scripts on the current computer
+ * @property {Function} flags See the ns.flags function for more information on usage
+ */
+
+/**
+ * Handler for autocomplete functionality
+ * @param {AutocompleteData} data General data about the game you may want to autocomplete.
+ * @param {array<string>} args current arguments minus "run script.js"
+ * @returns {array<string>} The valid values for auto completion
+ */
+export function autocomplete(data, args) {
+  if (args.length === 1) {
+    return data.scripts;
+  }
+
+  switch (args[args.length - 2]) {
+    case '--server':
+      return data.servers;
+    default:
+      return [...data.scripts, ...data.servers];
+  }
+}

--- a/src/source-files-map.js
+++ b/src/source-files-map.js
@@ -1,0 +1,56 @@
+/* Script that creates a JSON file of the players source files. Offloading this to a different
+ * file allows memory consumption to stay low during the bootstrapping process when the player
+ * first enters a bitnode.
+ */
+
+import { displayHelp } from './libs/help';
+
+const OUT_FILE = 'source-file-data.json';
+
+const FLAGS_DEF = [['help', false, 'Displays this help message']];
+const getHelpAdditionalLines = (scriptName) => [
+  `Usage: run ${scriptName}`,
+  'Example:',
+  `> run ${scriptName}`,
+];
+
+/**
+ * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
+ */
+export async function main(ns) {
+  const args = ns.flags(FLAGS_DEF);
+  if (args.help) {
+    const scriptName = ns.getScriptName();
+    return displayHelp({
+      ns,
+      description:
+        'This script collects information about the players source files.',
+      flagsDefinition: FLAGS_DEF,
+      additionalLines: getHelpAdditionalLines(scriptName),
+    });
+  }
+
+  const data = ns.getOwnedSourceFiles().map((e) => ({
+    id: e.n,
+    level: e.lvl,
+  }));
+  await ns.write(OUT_FILE, JSON.stringify(data), 'w');
+}
+
+/**
+ * @typedef {object} AutocompleteData https://bitburner.readthedocs.io/en/latest/netscript/advancedfunctions/autocomplete.html
+ * @property {array<string>} servers List of all servers in the game
+ * @property {array<string>} txts List of all text files on the current computer
+ * @property {array<string>} scripts List of all scripts on the current computer
+ * @property {Function} flags See the ns.flags function for more information on usage
+ */
+
+/**
+ * Handler for autocomplete functionality
+ * @param {AutocompleteData} data General data about the game you may want to autocomplete.
+ * @param {array<string>} args current arguments minux "run script.js"
+ * @returns {array<string>} The valid values for auto completion
+ */
+export function autocomplete(data, args) {
+  return [];
+}


### PR DESCRIPTION
* misc cleanup
* hackloop scheduler now dynamic based on how much mem available on "home" when bootstrap run
* refactored hackloop scheduler to make it a bit easier to read / maintain
* hackloop will self exit if there is no money on the server
* consolidated faction servers list
* created new script that measures RAM on a script and gives you approximate thread counts on various server sizes that could be run
* created source file map similar to net map. This can be consumed by future scripts for more play automation as source files become available